### PR TITLE
Fix/git flags includes git clean

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,13 +76,9 @@ components, colors, style, symbols.
 This variable defines the structure of the git status bar.  
 The default value is:
 
-    "#{git_clean} #{git_branch} - #{git_upstream} - #{git_remote} #{git_flags}"
+    "#{git_branch} - #{git_upstream} - #{git_remote} #{git_flags}"
 
 #### Status string keywords
-
-##### `#{git_clean}`
-
-Expands to ✔ if current working tree is *clean*.
 
 ##### `#{git_branch}`
 
@@ -104,7 +100,8 @@ Can either be:
 
 ##### `#{git_flags}`
 
-The `#{git_flags}` keyword expands into a succession of fields, each
+Expands to ✔ if current working tree is *clean*. If that's not the case
+the `#{git_flags}` keyword expands into a succession of fields, each
 representing a different piece of information about your git working tree:
  - ●n: there are n staged files
  - ✖n: there are n files with merge conflicts
@@ -112,7 +109,7 @@ representing a different piece of information about your git working tree:
  - …n: there are n untracked files
  - ⚑n: there are n stash entries
 
-The fields where the number would be 0 are ignored.  
+The fields where the number would be 0 are not displayed.  
 **Note:**
 If current working tree is *clean*, `#{git_flags}` is an empty string.
 
@@ -128,6 +125,19 @@ This defines what is shown instead of the git status bar whenever the current
 directory is not a Git working tree.  
 The default is any pre-exiting status-line.
 
+### Customize colors / styles
+
+Colors and styles can be modified. To do so simply redefine, anywhere in
+`tmux-gitbar.conf`, the variable you wish to modify; its default value will be
+overwritten. Colors and styles variables end with `_FMT`, like `BRANCH_FMT` and
+they represent tmux format strings.
+
+### Customize symbols
+
+Git flags symbols, the branch symbol, etc. can be modified. To do so simply
+redefine, anywhere in `tmux-gitbar.conf`, the symbol you wish to modify; its
+default value will be overwritten. Symbol variables end with `_SYMBOL`, like
+`BRANCH_SYMBOL`.
 
 # Credits
 

--- a/scripts/gitstatus.sh
+++ b/scripts/gitstatus.sh
@@ -3,7 +3,9 @@
 # gitstatus.sh -- produce the current git repo status on STDOUT
 # Functionally equivalent to 'gitstatus.py', but written in bash (not python).
 #
+# Original script by:
 # Alan K. Stebbens <aks@stebbens.org> [http://github.com/aks]
+# slightly modified for tmux-gitbar
 
 if [ -z "${__GIT_STATUS_CWD}" ]; then
   SOURCE="${BASH_SOURCE[0]}"

--- a/tmux-gitbar.conf
+++ b/tmux-gitbar.conf
@@ -1,56 +1,27 @@
-# tmux-gitstatus
-# Script for showing various git information in Tmux status bar
+# tmux-gitbar: git status in your tmux status bar
 #
-# Created by Aurélien Rainone / github.com/aurelien-rainone/tmux-gitstatus
-# The idea and the basecode (though largely modifified) initially comes
-# from a mix of tmux-git and bash-git-prompt, that were already intgrating
-# many ideas and code snippets from various places.
-# http://drmad.org/ with contributions
-# from many github users. Thank you all.
+# Created by Aurélien Rainone
+# github.com/aurelien-rainone/tmux-gitbar
 
 #
-# This is the tmux-gitstatus configuration file
+# This is the tmux-gitbar configuration file
 #
 
 # Location of the status on tmux bar: left or right
-TMGB_STATUS_LOCATION='right'
+readonly TMGB_STATUS_LOCATION='right'
 
-# Status for where you are out of a repo. Default is your pre-existing status 
-# line. Default to any previously defined status line string
-# Kudos to https://github.com/danarnold for the idea.
-TMGB_OUTREPO_STATUS=$(tmux show -vg status-$TMGB_STATUS_LOCATION)
+# Status for where you are out of a repo. Default is the pre-existing status 
+# line. Kudos to https://github.com/danarnold for the idea.
+readonly TMGB_OUTREPO_STATUS=$(tmux show -vg "status-$TMGB_STATUS_LOCATION")
 
 # Status line format string definition.
-# It controls what tmux-gitstatus will show in the status line. It can contain
-# any variable Tmux accepts, plus these ones:
+# It controls what tmux-gitbar will show in the status line. It accepts
+# any keyword or variable Tmux originally accepts, plus these ones:
 #
-# #{git_branch}   : expands to the name of current git branch.
-# #{git_remote}   : expands to the name of the currently tracked remote branch.
-# TODO: ajouter le cas ^ pour {git_remote}, par exemple vu adns un working tree
-# TODO: faire un commit CLEAN et ajouter des issue sur github, dans le nouvbeau repo
-# on peut pas continuer avec tous ces comments
-# #{git_upstream} : indication on the relation between local and remote branch,
-#                   expands to:
-#                    - ↑·N (or ↓·N) if local HEAD is N commits ahead (or behind)
-#                      the tracked remote branch.
-#                    - . (a dot) if local and remote are 'even'.
-#                    - L if there isn't remote tracking.
-# #{git_flags}    : expands to a succession of indicators detailing the working
-#                   tree status.
-#                   ● N : there are N files in the staging area.
-#                   ✖ N : there are N conficts.
-#                   ✚ N : there are N changes (that are not staged for commit).
-#                   ⚑ N : there are N stashed states in the stash list.
-#                   … N : there are N untracked files in the working tree.
+# - #{git_branch}   : local branch name
+# - #{git_remote}   : remote tracking branch
+# - #{git_upstream} : upstream branch info
+# - #{git_flags}    : working tree status flags
 #
-#                   NOTE: Indicators with a count of 0 are not represented.
-#
-# #{git_clean}    : expands to TMUXGIT_CLEAN_SYMBOL (default:✔) if working tree
-#                   is "clean", the empty string otherwise. The working tree is
-#                   considered clean if none of the ${git_flags} indicators are
-#                   present. In that sense #{git_flags} and #{git_clean} are
-#                   mutually exclusive.
-#
-TMGB_STATUS_STRING="#{git_clean} #{git_branch} - #{git_upstream} - #{git_remote} #{git_flags}"
-
-# vim: filetype=sh:tabstop=2:shiftwidth=2:expandtab
+# See README for additional information
+readonly TMGB_STATUS_STRING="#{git_branch} - #{git_upstream} - #{git_remote} #{git_flags}"

--- a/tmux-gitbar.sh
+++ b/tmux-gitbar.sh
@@ -7,7 +7,7 @@
 TMUX_GIT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 # Load the config file.
-config_file="${TMUX_GIT_DIR}/tmux-git.conf"
+config_file="${TMUX_GIT_DIR}/tmux-gitbar.conf"
 . "$config_file"
 
 # Symbols shown in status string


### PR DESCRIPTION
- `#{git_clean}` is integrated in `#{git_flags}` keyword
- read config file after defining default variables, so that they can
  be customized in conf file by simply redefining them
- update README.md
