### PR TITLE
Fix out of repo bg/fg colors

### DIFF
--- a/tmux-gitbar.conf
+++ b/tmux-gitbar.conf
@@ -10,9 +10,15 @@
 # Location of the status on tmux bar: left or right
 readonly TMGB_STATUS_LOCATION='right'
 
-# Status for where you are out of a repo. Default is the pre-existing status 
-# line. Kudos to https://github.com/danarnold for the idea.
+# background/foreground colors for tmux-gitbar
+readonly TMGB_BG_COLOR='black'
+readonly TMGB_FG_COLOR='white'
+
+# Status and colors for where you are out of a repo. Default are the #
+# pre-existing status line and colors. idea from https://github.com/danarnold
 readonly TMGB_OUTREPO_STATUS=$(tmux show -vg "status-$TMGB_STATUS_LOCATION")
+readonly TMGB_OUTREPO_FG_COLOR=$(tmux show -vg "status-$TMGB_STATUS_LOCATION-fg")
+readonly TMGB_OUTREPO_BG_COLOR=$(tmux show -vg "status-$TMGB_STATUS_LOCATION-bg")
 
 # Status line format string definition.
 # It controls what tmux-gitbar will show in the status line. It accepts

--- a/tmux-gitbar.sh
+++ b/tmux-gitbar.sh
@@ -165,6 +165,8 @@ update_gitbar() {
 
     read_git_info
 
+    tmux set-window-option "status-$TMGB_STATUS_LOCATION-fg" "$TMGB_FG_COLOR" > /dev/null
+    tmux set-window-option "status-$TMGB_STATUS_LOCATION-bg" "$TMGB_BG_COLOR" > /dev/null
     tmux set-window-option "status-$TMGB_STATUS_LOCATION-attr" bright > /dev/null
     tmux set-window-option "status-$TMGB_STATUS_LOCATION-length" 180 > /dev/null
 
@@ -182,6 +184,8 @@ update_gitbar() {
       # Be sure to unset GIT_DIRTY's bright when leaving a repository.
       # Kudos to https://github.com/danarnold for the idea
       tmux set-window-option "status-$TMGB_STATUS_LOCATION-attr" none > /dev/null
+      tmux set-window-option "status-$TMGB_STATUS_LOCATION-bg" "$TMGB_OUTREPO_BG_COLOR" > /dev/null
+      tmux set-window-option "status-$TMGB_STATUS_LOCATION-fg" "$TMGB_OUTREPO_FG_COLOR" > /dev/null
 
       # Set the out-repo status
       tmux set-window-option "status-$TMGB_STATUS_LOCATION" "$TMGB_OUTREPO_STATUS" > /dev/null


### PR DESCRIPTION
To be sure that default status bar shows approximately the same on
all configurations, we add bg/fg color to the `tmux-gitbar.conf`
This implied that we have to set the previous colors back when we
are out of repo (git working tree)
