### PR TITLE
Do not expose TMGB_OUTREPO_XXX variables

### DIFF
--- a/tmux-gitbar.conf
+++ b/tmux-gitbar.conf
@@ -6,7 +6,6 @@
 #
 # This is the tmux-gitbar configuration file
 #
-# Note: you can redefine any variable in this file, but they must be defined
 
 # Location of the status on tmux bar: left or right
 readonly TMGB_STATUS_LOCATION='right'

--- a/tmux-gitbar.conf
+++ b/tmux-gitbar.conf
@@ -26,16 +26,4 @@ readonly TMGB_FG_COLOR='white'
 # - #{git_flags}    : working tree status flags
 #
 # See README.md for additional information
-
 readonly TMGB_STATUS_STRING=" #{git_branch} - #{git_upstream} - #{git_remote} #{git_flags}"
-# Status for where you are out of a repo. Default is the pre-existing status
-# line. idea from https://github.com/danarnold
-readonly TMGB_OUTREPO_STATUS=$(tmux show -vg "status-$TMGB_STATUS_LOCATION")
-
-# Foreground color for where you are out of repo. Default is the pre-existing
-# foreground color.
-readonly TMGB_OUTREPO_FG_COLOR=$(tmux show -vg "status-$TMGB_STATUS_LOCATION-fg")
-
-# Background color for where you are out of repo. Default is the pre-existing
-# background color.
-readonly TMGB_OUTREPO_BG_COLOR=$(tmux show -vg "status-$TMGB_STATUS_LOCATION-bg")

--- a/tmux-gitbar.sh
+++ b/tmux-gitbar.sh
@@ -36,10 +36,31 @@ STASHED_FMT="#[fg=blue,bold]"
 UNTRACKED_FMT="#[fg=magenta,bold]"
 RESET_FMT="#[fg=default]"
 
+TMGB_OUTREPO_STATUS=""
+TMGB_OUTREPO_FG_COLOR=""
+TMGB_OUTREPO_BG_COLOR=""
+
 # Load the config file. overwriting any redefined variables
 readonly TMGB_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 config_file="${TMGB_DIR}/tmux-gitbar.conf"
 . "$config_file"
+
+# Save status bar settings so that we can reset it later
+save_statusbar() {
+
+  # Previous status string. Idea from https://github.com/danarnold
+  TMGB_OUTREPO_STATUS=$(tmux show -vg "status-$TMGB_STATUS_LOCATION")
+
+  # Previous foreground color
+  TMGB_OUTREPO_FG_COLOR=$(tmux show -vg "status-$TMGB_STATUS_LOCATION-fg")
+
+  # Previous background color
+  TMGB_OUTREPO_BG_COLOR=$(tmux show -vg "status-$TMGB_STATUS_LOCATION-bg")
+
+  readonly TMGB_OUTREPO_STATUS
+  readonly TMGB_OUTREPO_FG_COLOR
+  readonly TMGB_OUTREPO_BG_COLOR
+}
 
 # Use a different readlink according the OS.
 # Kudos to https://github.com/npauzenga for the PR
@@ -151,6 +172,18 @@ do_interpolation() {
   echo "$out"
 }
 
+# Reset tmux status bar to what it was before tmux-gitbar touched it
+reset_statusbar() {
+  # Be sure to unset GIT_DIRTY's bright when leaving a repository.
+  # Kudos to https://github.com/danarnold for the idea
+  tmux set-window-option "status-$TMGB_STATUS_LOCATION-attr" none > /dev/null
+  tmux set-window-option "status-$TMGB_STATUS_LOCATION-bg" "$TMGB_OUTREPO_BG_COLOR" > /dev/null
+  tmux set-window-option "status-$TMGB_STATUS_LOCATION-fg" "$TMGB_OUTREPO_FG_COLOR" > /dev/null
+
+  # Set the out-repo status
+  tmux set-window-option "status-$TMGB_STATUS_LOCATION" "$TMGB_OUTREPO_STATUS" > /dev/null
+}
+
 # Update tmux git status bar, called within PROMPT_COMMAND
 update_gitbar() {
 
@@ -181,16 +214,10 @@ update_gitbar() {
 
     if [[ $git_repo ]]; then
       export TMGB_LASTREPO="$git_repo"
+      save_statusbar
       update_gitbar
     else
-      # Be sure to unset GIT_DIRTY's bright when leaving a repository.
-      # Kudos to https://github.com/danarnold for the idea
-      tmux set-window-option "status-$TMGB_STATUS_LOCATION-attr" none > /dev/null
-      tmux set-window-option "status-$TMGB_STATUS_LOCATION-bg" "$TMGB_OUTREPO_BG_COLOR" > /dev/null
-      tmux set-window-option "status-$TMGB_STATUS_LOCATION-fg" "$TMGB_OUTREPO_FG_COLOR" > /dev/null
-
-      # Set the out-repo status
-      tmux set-window-option "status-$TMGB_STATUS_LOCATION" "$TMGB_OUTREPO_STATUS" > /dev/null
+      reset_statusbar
     fi
   fi
 }

--- a/tmux-gitbar.sh
+++ b/tmux-gitbar.sh
@@ -9,7 +9,8 @@ readonly REMOTE_KWD="\#{git_remote}"
 readonly UPSTREAM_KWD="\#{git_upstream}"
 readonly FLAGS_KWD="\#{git_flags}"
 
-# Default symbols shown in status string. Can be redefined in tmux-gitbar.conf
+# Symbols shown in status string.
+# Can be redefined here, or preferably in tmux-gitbar.conf
 NO_REMOTE_TRACKING_SYMBOL="L";
 BRANCH_SYMBOL="⭠";
 STAGED_SYMBOL="●"
@@ -22,8 +23,8 @@ AHEAD_SYMBOL="↑·"
 BEHIND_SYMBOL="↓·"
 PREHASH_SYMBOL=":"
 
-# Defaut Tmux format strings for Git bar components. Can be redefined in 
-# tmux-gitbar.conf
+# Defaut Tmux format strings for Git bar components.
+# Can be redefined here, or preferably in tmux-gitbar.conf
 BRANCH_FMT="#[fg=white]"
 UPSTREAM_FMT="#[fg=cyan]"
 REMOTE_FMT="#[fg=cyan]"
@@ -67,6 +68,7 @@ find_git_repo() {
   return
 }
 
+# Search branch info and replace with symbols
 replace_branch_symbols() {
 
   local s1; local s2; local s3


### PR DESCRIPTION
Add save_statusbar and reset_statusbar functions

Expose TMGB_OUTREPO_XXX variables in the conf file was useless
It's kind of obvious that you want to come back to your previous
status bar when you are not in a Git working tree.
And the definition of the 'out of repo' status bar should be done
outside of tmux-gitbar.
So we need this variable to reset the status bar to its previous state, but they are meant to be internal
to tmux-gitbar and not exposed as configuration 
