### PR TITLE
Fix Error on tmux.conf reload

### DIFF
--- a/tmux-gitbar.tmux
+++ b/tmux-gitbar.tmux
@@ -4,4 +4,4 @@
 # github.com/aurelien-rainone/tmux-gitbar
 
 # install update-gitbar as a prompt command
-if-shell 'test -z "${TMUX_GITBAR_DIR}"' PROMPT_COMMAND="~/.tmux-gitbar/update-gitbar; $PROMPT_COMMAND" PROMPT_COMMAND="$TMUX_GITBAR_DIR/update-gitbar; $PROMPT_COMMAND"
+if-shell 'test -z "${TMUX_GITBAR_DIR}"' 'PROMPT_COMMAND="~/.tmux-gitbar/update-gitbar; $PROMPT_COMMAND"' 'PROMPT_COMMAND="$TMUX_GITBAR_DIR/update-gitbar; $PROMPT_COMMAND"'


### PR DESCRIPTION
The `if-shell` expression, in `tmux-gitbar.tmux`, installing the
`PROMPT_COMMAND` was failing on tmux.conf reloading.  The problem was
seemingly due to different _variable expansion rules_ when loading the
file, or when relaoding it from inside a tmux-session.

Single quoting both expressions after the `if-shell` command fixed it.

Fixes #18 
