### PR TITLE
Protect from multiple prompt_command calls

### DIFF
--- a/tmux-gitbar.tmux
+++ b/tmux-gitbar.tmux
@@ -3,5 +3,8 @@
 # Created by Aurélien Rainone
 # github.com/aurelien-rainone/tmux-gitbar
 
-# install update-gitbar as a prompt command
-if-shell 'test -z "${TMUX_GITBAR_DIR}"' 'PROMPT_COMMAND="~/.tmux-gitbar/update-gitbar; $PROMPT_COMMAND"' 'PROMPT_COMMAND="$TMUX_GITBAR_DIR/update-gitbar; $PROMPT_COMMAND"'
+# install update-gitbar as a prompt command if not done already
+if-shell 'echo $PROMPT_COMMAND | grep -qv update-gitbar' \
+  "if-shell 'test -z \"${TMUX_GITBAR_DIR}\"' \
+    'PROMPT_COMMAND=\"~/.tmux-gitbar/update-gitbar; $PROMPT_COMMAND\"' \
+    'PROMPT_COMMAND=\"$TMUX_GITBAR_DIR/update-gitbar; $PROMPT_COMMAND\"'"


### PR DESCRIPTION
Before modifying the `$PROMPT_COMMAND`, we check that it doesn't
contain `update-gitbar` already.
Use multiline strings for cosmetics considerations.
Closes #21
