### PR TITLE
Add integration tests suite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,18 @@
+before_install:
+  - sudo apt-get update
+  - sudo apt-get install -qq expect
+
+install:
+  - # install supported version Tmux 1.9a
+  - sudo add-apt-repository -y ppa:pi-rho/dev
+  - sudo apt-get update
+  - sudo apt-get install -y tmux=1.9a-1~ppa1~p
+
 before_script:
   - git clone https://github.com/sstephenson/bats.git /tmp/bats
   - mkdir -p /tmp/local
   - bash /tmp/bats/install.sh /tmp/local
   - export PATH=$PATH:/tmp/local/bin
 script:
-  - bats test/*.bats
+  - bats test/unit-tests/*.bats
+  - bash test/integration-tests/run_integration_tests.sh

--- a/README.md
+++ b/README.md
@@ -230,6 +230,9 @@ Other credits for :
 
 # Changelog
 
+### v1.2.0, 2016-03-26
+- Add integration test suite
+
 ### v1.1.1, 2016-03-10
 - Replace deprecated status-xxx-fg/bg/attr syntax with the new style syntax
 - Fix issue 23 'bad colour' error

--- a/test/integration-tests/helpers/expect_helpers.tcl
+++ b/test/integration-tests/helpers/expect_helpers.tcl
@@ -1,0 +1,66 @@
+# general functions for expect scripts
+
+# basic setup for each script
+proc expect_setup {} {
+  # disables script output
+  log_user 0
+  # standard timeout
+  set timeout 2
+}
+
+proc exit_status_false {} {
+  global exit_status
+  set exit_status 1
+}
+
+proc send_cd {dir} {
+  send "cd $dir\r"
+  sleep 0.5
+}
+
+proc teardown_and_exit {} {
+  global exit_status
+  kill_tmux_server
+  exit $exit_status
+}
+
+proc clear_screen {} {
+  send ""
+  sleep 0.5
+}
+
+proc assert_on_screen {text message} {
+  expect {
+    "$text" {
+      puts "  Success: $message"
+    }
+    timeout {
+      puts "  Fail: $message"
+      exit_status_false
+    }
+  }
+}
+
+proc assert_on_screen_regex {text message} {
+  expect {
+    -re "$text" {
+      puts "  Success: $message"
+    }
+    timeout {
+      puts "  Fail: $message"
+      exit_status_false
+    }
+  }
+}
+
+proc assert_colored {text color} {
+  # TODO: to implement
+  puts "To IMPLEMENT"
+}
+
+proc assert_style {text color} {
+  # TODO: to implement
+  # PRENDRE EXAMPLE DANS tmux-copycat, assert_highlighted
+  puts "To IMPLEMENT"
+}
+

--- a/test/integration-tests/helpers/expect_setup.tcl
+++ b/test/integration-tests/helpers/expect_setup.tcl
@@ -1,0 +1,8 @@
+# expect setup
+
+source ./test/integration-tests/helpers/expect_helpers.tcl
+source ./test/integration-tests/helpers/tmux_helpers.tcl
+expect_setup
+
+# exit status global var is successful by default
+set exit_status 0

--- a/test/integration-tests/helpers/tmux_bats_helpers.bash
+++ b/test/integration-tests/helpers/tmux_bats_helpers.bash
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+# tmux-gitbar: Git in tmux status bar
+#
+# Created by Aurélien Rainone
+# github.com/aurelien-rainone/tmux-gitbar
+
+# helpers functions for bats integration tests
+
+# Append a 'set-option' cmd to tmux.conf
+set_option_in_tmux_conf() {
+  option="$1"
+  value="$2"
+  echo set-option -g "'$option'" "'$value'" >> "${TMUXCONF}"
+}
+
+# Append a 'set-window-option' cmd to tmux.conf
+setw_option_in_tmux_conf() {
+  option="$1"
+  value="$2"
+  echo set-window-option -g "'$option'" "'$value'" >> "${TMUXCONF}"
+}
+
+# Set gitbar location to left, in tmux-gitbar configuration file
+set_tmgb_location_left() {
+
+  TMGBCONF="$PWD/tmux-gitbar.conf"
+  # In-place modification of tmux-gitbar.conf
+  ed -s $TMGBCONF <<< $',s/\(TMGB_STATUS_LOCATION\)=.*/\\1=\'left\'\nw' > /dev/null
+}
+
+# Clear gitbar status string, in tmux-gitbar configuration file
+clear_tmgb_string() {
+
+  TMGBCONF="$PWD/tmux-gitbar.conf"
+  # In-place modification of tmux-gitbar.conf
+  ed -s $TMGBCONF <<< $',s/\(TMGB_STATUS_STRING\)=.*/\\1=\'\'\nw' > /dev/null
+}
+
+# Restore the default tmux-gitbar.conf
+restore_tmgb_conf() {
+  echo '' > /dev/null
+  git checkout tmux-gitbar.conf
+}

--- a/test/integration-tests/helpers/tmux_helpers.tcl
+++ b/test/integration-tests/helpers/tmux_helpers.tcl
@@ -1,0 +1,12 @@
+# tmux functions for expect scripts
+
+proc kill_tmux_server {} {
+  send "tmux kill-server\r"
+  sleep 0.2
+}
+
+proc tmux_set_option {key value} {
+  set cmd "tmux set-option \"$key\" \"$value\""
+  send "$cmd"
+}
+

--- a/test/integration-tests/in_and_out_of_working_tree.tcl
+++ b/test/integration-tests/in_and_out_of_working_tree.tcl
@@ -1,0 +1,28 @@
+#!/usr/bin/env expect -d
+
+source ./test/integration-tests/helpers/expect_setup.tcl
+
+set mockrepo $env(MOCKREPO)
+
+# move into our mock repo directory
+cd $mockrepo
+
+# Run tmux
+spawn tmux -f $env(TMUXCONF)
+
+# Wait for tmux to launch and attach
+sleep 1
+
+# As tmux started in-tree, expect to see the branch name
+assert_on_screen "origin/master" "should show git branch name"
+
+# Goes out of tree
+send_cd /
+assert_on_screen "out of working tree" "should show out-of-tree status string"
+
+# Turn back into the git working tree
+send_cd $mockrepo
+assert_on_screen "origin/master" "should show git branch name"
+
+# End of test: success!
+teardown_and_exit

--- a/test/integration-tests/main.bats
+++ b/test/integration-tests/main.bats
@@ -1,0 +1,55 @@
+#!/usr/bin/env bats
+
+# tmux-gitbar: Git in tmux status bar
+#
+# Created by Aurélien Rainone
+# github.com/aurelien-rainone/tmux-gitbar
+
+load "../test_helper"
+load "helpers/tmux_bats_helpers"
+
+setup() {
+  restore_tmgb_conf
+  create_test_repo
+  backup_pwd
+}
+
+# Covers both display modes of tmux-gitbar, in and out of a Git working tree,
+# and how we switch form one to another
+@test "behaviour in and out of git working tree" {
+  set_option_in_tmux_conf 'status-right' '[out of working tree]'
+  expect "${BATS_TEST_DIRNAME}/in_and_out_of_working_tree.tcl"
+}
+
+# Check the code relying on TMGB_STATUS_LOCATION works without side effects
+@test "tmux-gitbar can show on the left" {
+
+  set_tmgb_location_left
+  set_option_in_tmux_conf 'status-left' '[out of working tree]'
+  set_option_in_tmux_conf 'status-right' '[right]'
+  expect -d "${BATS_TEST_DIRNAME}/tmux-gitbar_location.tcl" -- left
+}
+
+# Check the code relying on TMGB_STATUS_LOCATION works without side effects
+@test "tmux-gitbar can show on the right" {
+
+  # Default tmux-gitbar location is on the right
+  set_option_in_tmux_conf 'status-right' '[out of working tree]'
+  set_option_in_tmux_conf 'status-left' '[left]'
+  expect "${BATS_TEST_DIRNAME}/tmux-gitbar_location.tcl" -- right
+}
+
+# Check that nothing is written on stdout/err during the execution of the 
+# PROMPT_COMMAND. This could happen if a tmux command produces some error
+# output (see issue #23 for example)
+@test "PROMPT_COMMAND does not print nothing on terminal" {
+
+  set_option_in_tmux_conf 'status' 'off'
+  expect -d "${BATS_TEST_DIRNAME}/no_extra_output.tcl"
+}
+
+teardown() {
+  restore_pwd
+  cleanup_test_repo
+  restore_tmgb_conf
+}

--- a/test/integration-tests/no_extra_output.tcl
+++ b/test/integration-tests/no_extra_output.tcl
@@ -1,0 +1,54 @@
+#!/usr/bin/env expect
+
+# Test description
+#
+#     This script tests that update-gitbar does not output nothing to stdout.
+#      - running update-gitbar in PROMPT_COMMAND should obviously not produce
+#        any output, even in case of error, as such output would be written 
+#        into the user terminal before executing any command.
+# How does this test works?
+#
+# - Set the PS1 env var to PROMPT so that it is easily recognizable.
+# - run an *echo A* command on the terminal.
+# - check the output produced on the terminal, it should only contain, in this
+#   order:
+#   - PROMPTecho A
+#   - only CR or LF or ANSI escape sequences
+#   - A (the one output by previous echo)
+#   - only CR or LF or ANSI escape sequences
+#   - PROMPT
+# If this sequence is not matched that mean that some output has been produced
+# and the text fails
+
+source ./test/integration-tests/helpers/expect_setup.tcl
+
+# Run tmux
+spawn tmux -f $env(TMUXCONF)
+
+# Wait for tmux to launch and attach
+sleep 1
+log_user 1
+
+# Disable prompt and clear screen
+send "PS1='PROMPT'"
+sleep 0.5
+clear_screen
+
+send "echo A"
+
+# ANSI control character sequence
+set ansi {(?:[\x1b\x9b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcdf-nqry=><])*?}
+set crlf {(?:\r\n)*}
+set nonvisibles "(?:$crlf|$ansi)*"
+
+set str "PROMPTecho A"
+append str $nonvisibles
+append str "A"
+append str $nonvisibles
+append str "PROMPT"
+
+# As tmux started in-tree, expect to see the branch name
+assert_on_screen_regex $str "No output should be produced by update-gitbar"
+
+## End of test: success!
+teardown_and_exit

--- a/test/integration-tests/run_integration_tests.sh
+++ b/test/integration-tests/run_integration_tests.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+export TMUXCONF="$PWD/tmux.conf"
+
+# Create a minimal tmux conf file
+> "${TMUXCONF}"
+echo TMUX_GITBAR_DIR=\"$PWD\" >> "${TMUXCONF}"
+echo source-file \"$PWD/tmux-gitbar.tmux\" >> "${TMUXCONF}"
+
+bats test/integration-tests/main.bats

--- a/test/integration-tests/tmux-gitbar_location.tcl
+++ b/test/integration-tests/tmux-gitbar_location.tcl
@@ -1,0 +1,47 @@
+#!/usr/bin/env expect -d
+
+source ./test/integration-tests/helpers/expect_setup.tcl
+
+set mockrepo $env(MOCKREPO)
+set tmgb_loc [lindex $argv 0]
+
+# move into our mock repo directory
+cd $mockrepo
+
+# Run tmux
+spawn tmux -f $env(TMUXCONF)
+
+# Wait for tmux to launch and attach
+sleep 1
+
+# Test gitbar location when inside a git working tree
+if {$tmgb_loc == {right}} {
+
+  assert_on_screen_regex \
+    {left.*origin/master} \
+    "branch name should show on the right"
+
+} elseif {$tmgb_loc == {left}} {
+
+  assert_on_screen_regex \
+    {origin/master.*right} \
+    "branch name should show on the left"
+}
+
+# Test gitbar location outside of git working tree
+send_cd /
+if {$tmgb_loc == {right}} {
+
+  assert_on_screen_regex \
+    {left.*out of working tree} \
+    "out of repo status string should show on the right"
+
+} elseif {$tmgb_loc == {left}} {
+
+  assert_on_screen_regex \
+    {out of working tree.*right} \
+    "out of repo status string should show on the left"
+}
+
+# End of test: success!
+teardown_and_exit

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -6,12 +6,14 @@
 # github.com/aurelien-rainone/tmux-gitbar
 
 export MOCKREPO="${BATS_TMPDIR}/mock-repo"
-export ROOTDIR="${BATS_TEST_DIRNAME}/.."
+export ROOTDIR="${BATS_TEST_DIRNAME}/../.."
 
 create_test_repo() {
 
   working_tree="$MOCKREPO"
   repo="${working_tree}.git"
+
+  backup_pwd
 
   # create the repository
   git init -q --bare "$repo"
@@ -30,6 +32,8 @@ create_test_repo() {
   git add file1 file2 file3
   git commit -m 'commit 3 files'
   git push --set-upstream origin master
+
+  restore_pwd
 }
 
 cleanup_test_repo() {
@@ -39,4 +43,12 @@ cleanup_test_repo() {
 
   [ -d "$working_tree" ] && rm -rf "$working_tree"/
   [ -d "$repo" ] && rm -rf "$repo"/
+}
+
+backup_pwd() {
+  pushd . > /dev/null
+}
+
+restore_pwd() {
+  popd > /dev/null
 }

--- a/test/unit-tests/functions.bats
+++ b/test/unit-tests/functions.bats
@@ -5,7 +5,7 @@
 # Created by Aurélien Rainone
 # github.com/aurelien-rainone/tmux-gitbar
 
-load test_helper
+load "../test_helper"
 load "${ROOTDIR}/lib/tmux-gitbar.sh"
 load "${ROOTDIR}/scripts/helpers.sh"
 

--- a/test/unit-tests/git.bats
+++ b/test/unit-tests/git.bats
@@ -5,13 +5,13 @@
 # Created by Aurélien Rainone
 # github.com/aurelien-rainone/tmux-gitbar
 
-load test_helper
+load "../test_helper"
 load "${ROOTDIR}/lib/tmux-gitbar.sh"
 load "${ROOTDIR}/scripts/helpers.sh"
 
 setup() {
   create_test_repo
-  pushd . > /dev/null
+  backup_pwd
 }
 
 @test "detect when in a git working tree" {
@@ -151,6 +151,6 @@ setup() {
 }
 
 teardown() {
-  popd > /dev/null
+  restore_pwd
   cleanup_test_repo
 }

--- a/test/unit-tests/misc.bats
+++ b/test/unit-tests/misc.bats
@@ -5,7 +5,7 @@
 # Created by Aurélien Rainone
 # github.com/aurelien-rainone/tmux-gitbar
 
-load test_helper
+load "../test_helper"
 
 @test "there is a configuration file" {
   [ -f "$ROOTDIR/tmux-gitbar.conf" ]


### PR DESCRIPTION
- keep unit-tests and integration-tests into separated dirs
- modify path accordingly in .travis.yml and test_helper.bash
- integration tests:
  - call run_integration_tests from travis
  - generate a minimal config file on the fly
  - use a ppa with the first supported tmux version: 1.9
  - refactor some unit/integration helpers functions
