### PR TITLE
Moved tmux-gitbar.conf out of the repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,0 @@
-tmux-gitbar.conf

--- a/README.md
+++ b/README.md
@@ -275,6 +275,9 @@ from those 2 great projects:
  - [bash-git-prompt][3] an informative and fancy bash prompt for Git users.
  - [tmux-git][4] a script for showing current Git branch in Tmux status bar
 
+Contributers:
+ - [AlexKornitzer][7]
+
 Other credits for :
  - [tmux/tmux][1]
  - [gh-md-toc][6]
@@ -339,3 +342,4 @@ configuration.
 [4]: https://github.com/drmad/tmux-git
 [5]: https://github.com/runsisi/consolas-font-for-powerline
 [6]: https://github.com/ekalinin/github-markdown-toc
+[7]: https://github.com/AlexKornitzer

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Show **Local** and **Remote** Git branches information:
    issue, or even better, a pull-request, in case you discover any kind of
    incompatibility with a tmux plugin you are using.
 
-**Customizable**  
+**Customizable**
 You can customize the content and the style of the Git status bar, this is all
 done in `tmux-gitbar.conf`, this file is auto-generated at first launch, in the
 installation directory.
@@ -54,7 +54,7 @@ installation directory.
   * [Status bar location](#status-bar-location)
   * [Status bar color](#status-bar-color)
   * [Symbols](#symbols)
-* [Troubleshooting](#troubleshooting) 
+* [Troubleshooting](#troubleshooting)
 * [Credits](#credits)
 * [License](#license)
 * [Changelog](#changelog)
@@ -93,7 +93,7 @@ Let's say you prefer to install **tmux-gitbar** in
 git clone https://github.com/aurelien-rainone/tmux-gitbar.git /path/to/tmux-gitbar
 ```
 
-**Add those 2 lines to your `tmux.conf`**
+**Add these 2 lines to your `tmux.conf`**
 
 ```bash
 TMUX_GITBAR_DIR="/path/to/tmux-gitbar"
@@ -101,9 +101,19 @@ source-file "/path/to/tmux-gitbar/tmux-gitbar.tmux"
 ```
 
 **Important:** `TMUX_GITBAR_DIR` environment variable **must be set** before
-sourcing `tmux-gitbar.tmux`.  
+sourcing `tmux-gitbar.tmux`.
 **Note:** Do not include the trailing slash.
 
+
+## Modifying tmux-gitbar.conf location
+
+If you prefer to store the **.tmux-gitbar.conf** somewhere other than `~/`.
+
+**Add this line to your `tmux.conf`**
+
+```bash
+TMUX_GITBAR_CONF="/path/to/.tmux-gitbar.conf"
+```
 
 ## Font
 
@@ -149,7 +159,7 @@ the default `BRANCH_SYMBOL has been replaced.
 
 # Documentation
 
-Customizing the location and appearance of tmux-gitbar is realized in 
+Customizing the location and appearance of tmux-gitbar is realized in
 `tmux-gitbar.conf`, this file is auto-generated at first launch if it doesn't
 exist already.
 
@@ -203,7 +213,7 @@ Shows the `⭠` symbol followed by the local branch name.
 |`…n`|there are n untracked files|
 |`⚑n`|there are n stash entries|
 
-Flags with number being 0 are not shown.  
+Flags with number being 0 are not shown.
 The working tree is considered *clean* if all flags are 0, in this case a `✔`
 is shown.
 
@@ -228,7 +238,7 @@ tmux-gitbar background color. Default is black.
 ## Symbols
 
 You can replace the default symbols with others. Symbols defined in
-`tmux-gitbar.conf` take precedence over the default ones.  
+`tmux-gitbar.conf` take precedence over the default ones.
 For example, if you want to use the `x` to represent conflicts, instead of the
 default '✖' (unicode 0x2716), simply add to your `tmux-gitbar.conf`:
 
@@ -282,7 +292,7 @@ Other credits for :
 - Fix issue 10: some symbols do not render with the stock font
 
 ### v1.3.0, 2016-04-02
-- `tmux-gitbar.conf` is not version controlled any more, and generated at first 
+- `tmux-gitbar.conf` is not version controlled any more, and generated at first
 launch, allowing to update tmux-gitbar without overwriting user-customized
 configuration.
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ installation directory.
 * [How-to install](#how-to-install)
   * [Default installation](#default-installation)
   * [Installing to another location](#installing-to-another-location)
+  * [Configuration file](#configuration-file)
   * [Font](#font)
 * [Examples](#examples)
 * [Documentation](#documentation)

--- a/README.md
+++ b/README.md
@@ -105,9 +105,12 @@ sourcing `tmux-gitbar.tmux`.
 **Note:** Do not include the trailing slash.
 
 
-## Modifying tmux-gitbar.conf location
+## Configuration file
 
-If you prefer to store the **.tmux-gitbar.conf** somewhere other than `~/`.
+**tmux-gitbar** auto-generates its own configuration file at first launch
+and places it in `$HOME/.tmux-gitbar.conf`. If for whatever reasons you
+would like to store it somewhere else, or rename it, just define
+`$TMUX_GITBAR_CONF`.
 
 **Add this line to your `tmux.conf`**
 

--- a/lib/tmux-gitbar.sh
+++ b/lib/tmux-gitbar.sh
@@ -44,9 +44,13 @@ RESET_FMT="#[fg=default]"
 TMGB_OUTREPO_STATUS=""
 TMGB_OUTREPO_STYLE=""
 
+if [ -z ${TMUX_GITBAR_CONF} ]; then
+  TMUX_GITBAR_CONF=${HOME}/.tmux-gitbar.conf
+fi
+
 # Load the config file
 load_config() {
-  source "${SCRIPT_DIR}/../tmux-gitbar.conf"
+  source "${TMUX_GITBAR_CONF}"
 }
 
 # Save status bar settings so that we can reset it later

--- a/test/integration-tests/run_integration_tests.sh
+++ b/test/integration-tests/run_integration_tests.sh
@@ -5,6 +5,7 @@ export TMUXCONF="$PWD/tmux.conf"
 # Create a minimal tmux conf file
 > "${TMUXCONF}"
 echo TMUX_GITBAR_DIR=\""$PWD"\" >> "${TMUXCONF}"
+echo TMUX_GITBAR_CONF=\""$PWD/tmux-gitbar.conf"\" >> "${TMUXCONF}"
 echo source-file \""$PWD/tmux-gitbar.tmux"\" >> "${TMUXCONF}"
 
 bats test/integration-tests/main.bats

--- a/tmux-gitbar.tmux
+++ b/tmux-gitbar.tmux
@@ -3,15 +3,18 @@
 # Created by Aurélien Rainone
 # github.com/aurelien-rainone/tmux-gitbar
 
-# generate tmux-gitbar.conf if it doesn't exist
+# ensure TMUX_GITBAR_DIR is defined
 if-shell 'test -z ${TMUX_GITBAR_DIR}' \
-  "if-shell '! stat ~/.tmux-gitbar/tmux-gitbar.conf' \
-    'run-shell \"~/.tmux-gitbar/lib/generate-config.sh ~/.tmux-gitbar/tmux-gitbar.conf\"'" \
-  "if-shell '! stat $TMUX_GITBAR_DIR/tmux-gitbar.conf' \
-    'run-shell \"$TMUX_GITBAR_DIR/lib/generate-config.sh $TMUX_GITBAR_DIR/tmux-gitbar.conf\"'"
+  'TMUX_GITBAR_DIR="$HOME/.tmux-gitbar"'
+
+# ensure TMUX_GITBAR_CONF is defined
+if-shell 'test -z ${TMUX_GITBAR_CONF}' \
+  'TMUX_GITBAR_CONF="$HOME/.tmux-gitbar.conf"'
+
+# generate configuration file if it doesn't exist
+if-shell '! stat ${TMUX_GITBAR_CONF}' \
+  'run-shell "$TMUX_GITBAR_DIR/lib/generate-config.sh $TMUX_GITBAR_CONF"'
 
 # install update-gitbar as a prompt command if not done already
 if-shell 'echo $PROMPT_COMMAND | grep -qv update-gitbar' \
-  "if-shell 'test -z \"${TMUX_GITBAR_DIR}\"' \
-    'PROMPT_COMMAND=\"~/.tmux-gitbar/update-gitbar; $PROMPT_COMMAND\"' \
-    'PROMPT_COMMAND=\"$TMUX_GITBAR_DIR/update-gitbar; $PROMPT_COMMAND\"'"
+  'PROMPT_COMMAND="$TMUX_GITBAR_DIR/update-gitbar; $PROMPT_COMMAND"'


### PR DESCRIPTION
Right so the bash version took me about 4 seconds to knock out but the tmux version took ages (I still dont get it!).

So the tmux version will work the same way as before, there are now to variables that can be set:
```
TMUX_GITBAR_CONF
TMUX_GITBAR_DIR
```

The bash version is in scripts and can just be used by putting
```
TMUX_GITBAR_DIR/scripts/setup.sh
```
in .bashrc

Feel free to remove the bash version, but I just feel that this is much cleaner and as this project is bash dependent I would suggest this may be the better way to go!

I haven't updated the docs yet incase any of this implementation changes during the PR.

Hopefully travis is ready to run the tests.