### PR TITLE
Initial rc support

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ installation directory.
   * [Status bar location](#status-bar-location)
   * [Status bar color](#status-bar-color)
   * [Symbols](#symbols)
+  * [Ignoring repositories](#ignoring-repositories)
 * [Troubleshooting](#troubleshooting)
 * [Credits](#credits)
 * [License](#license)
@@ -250,6 +251,15 @@ default '✖' (unicode 0x2716), simply add to your `tmux-gitbar.conf`:
 CONFLICT_SYMBOL="x"
 ```
 
+## Ignoring Repositories
+
+You can ignore a repository by adding the file `.tmgbignore` to the root of the
+repository to be ignored. This will stop tmux-gitbar from showing for the
+targeted repository.
+
+```bash
+touch "/path/to/repo/.tmgbignore"
+```
 
 # Troubleshooting
 

--- a/lib/tmux-gitbar.sh
+++ b/lib/tmux-gitbar.sh
@@ -172,6 +172,12 @@ update_gitbar() {
 
     read_git_info
 
+    # Check if we ignore the repo
+    if [[ -f "$git_repo/.tmgbignore" ]]; then
+      reset_statusbar
+      return
+    fi
+
     # append Git status to current status string
     local status_string
     status_string="#[$TMGB_OUTREPO_STYLE]$TMGB_OUTREPO_STATUS#[$TMGB_STYLE]$(do_interpolation "${TMGB_STATUS_STRING}")"

--- a/test/integration-tests/main.bats
+++ b/test/integration-tests/main.bats
@@ -44,7 +44,13 @@ setup() {
   expect "${BATS_TEST_DIRNAME}/tmux-gitbar_location.tcl" -- right
 }
 
-# Check that nothing is written on stdout/err during the execution of the 
+# Check that tmux-gitbar will detect .tmgbignore if present and hide
+@test "tmux-gitbar can ignore repo" {
+  set_option_in_tmux_conf 'status-right' '#[fg=default,bg=default]status'
+  expect -d "${BATS_TEST_DIRNAME}/tmux-gitbar_ignore.tcl"
+}
+
+# Check that nothing is written on stdout/err during the execution of the
 # PROMPT_COMMAND. This could happen if a tmux command produces some error
 # output (see issue #23 for example)
 @test "PROMPT_COMMAND does not print nothing on terminal" {

--- a/test/integration-tests/tmux-gitbar_ignore.tcl
+++ b/test/integration-tests/tmux-gitbar_ignore.tcl
@@ -1,0 +1,41 @@
+#!/usr/bin/env expect -d
+
+source ./test/integration-tests/helpers/expect_setup.tcl
+
+set mockrepo $env(MOCKREPO)
+
+# Move into our mock repo directory
+cd $mockrepo
+
+# Run tmux
+spawn tmux -f $env(TMUXCONF)
+
+# Wait for tmux to launch and attach
+sleep 1
+
+# tmux is started inside a git-tree directory, so we expect the status bar to
+# be composed of the 'normal' tmux status, followed by the branch name
+assert_on_screen_regex "status.*origin/master" "should show previous status + git status"
+
+# Create the ignore file
+set fp [ open ".tmgbignore" w]
+close $fp
+
+# tmux status line should be empty inside and outside the repo
+send_cd $mockrepo
+assert_on_screen "status" "should show normal status string"
+assert_not_on_screen "origin/master" "should not show git status"
+send_cd /
+assert_on_screen "status" "should show normal status string"
+assert_not_on_screen "origin/master" "should not show git status"
+send_cd $mockrepo
+assert_on_screen "status" "should show normal status string"
+assert_not_on_screen "origin/master" "should not show git status"
+
+# Delete ignore file and check for status
+file delete ".tmgbignore"
+send_cd $mockrepo
+assert_on_screen_regex "status.*origin/master" "should show normal status + git branch"
+
+# End of test: success!
+teardown_and_exit


### PR DESCRIPTION
This is basically a clone of functionality available in bash-git-prompt.
ATM it only supports the ability to ignore repos in the same way as the
aforementioned project.

The above kind of covers it, haven't updated the README incase you reject the changes or wish to change aspects of this. Have only `ported` the ignore feature as I use it. It currently supports TMUX_GITBAR_IGNORE and stores it in .tmux-gitbar-rc